### PR TITLE
Migrate project to null-safety

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -7,42 +7,42 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0-nullsafety.1"
+    version: "2.8.2"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety.1"
+    version: "2.1.0"
   characters:
     dependency: transitive
     description:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety.3"
+    version: "1.2.0"
   charcode:
     dependency: transitive
     description:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0-nullsafety.1"
+    version: "1.3.1"
   clock:
     dependency: transitive
     description:
       name: clock
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety.1"
+    version: "1.1.0"
   collection:
     dependency: transitive
     description:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0-nullsafety.3"
+    version: "1.15.0"
   convert:
     dependency: transitive
     description:
@@ -63,7 +63,7 @@ packages:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0-nullsafety.1"
+    version: "1.2.0"
   file:
     dependency: transitive
     description:
@@ -71,13 +71,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "5.2.1"
-  file_testing:
-    dependency: transitive
-    description:
-      name: file_testing
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.1.0"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -108,21 +101,28 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.10-nullsafety.1"
+    version: "0.12.11"
+  material_color_utilities:
+    dependency: transitive
+    description:
+      name: material_color_utilities
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.3"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0-nullsafety.3"
+    version: "1.7.0"
   path:
     dependency: transitive
     description:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0-nullsafety.1"
+    version: "1.8.0"
   petitparser:
     dependency: transitive
     description:
@@ -141,56 +141,56 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0-nullsafety.2"
+    version: "1.8.1"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.10.0-nullsafety.1"
+    version: "1.10.0"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety.1"
+    version: "2.1.0"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety.1"
+    version: "1.1.0"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0-nullsafety.1"
+    version: "1.2.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19-nullsafety.2"
+    version: "0.4.8"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0-nullsafety.3"
+    version: "1.3.0"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety.3"
+    version: "2.1.1"
   xml:
     dependency: transitive
     description:
@@ -199,4 +199,4 @@ packages:
     source: hosted
     version: "4.5.1"
 sdks:
-  dart: ">=2.10.0-110 <2.11.0"
+  dart: ">=2.14.0 <3.0.0"

--- a/lib/flutter_native_strings.dart
+++ b/lib/flutter_native_strings.dart
@@ -6,14 +6,13 @@ import 'package:file/file.dart';
 import 'package:flutter_native_strings/src/data/constants.dart';
 import 'package:flutter_native_strings/src/util/logger/logger.dart';
 import 'package:flutter_native_strings/src/util/string_resource_creator/string_resource_creator_i.dart';
-import 'package:meta/meta.dart';
 
 class FlutterNativeStrings {
   void generateNativeStrings(
-      {@required LoggerI logger,
-      @required FileSystem fileSystem,
-      @required String arbFilePath,
-      @required StringResourceCreatorI androidStringResourceCreator}) {
+      {required LoggerI logger,
+      required FileSystem fileSystem,
+      required String arbFilePath,
+      required StringResourceCreatorI androidStringResourceCreator}) {
     try {
       logger.printMessage(
           message:
@@ -21,9 +20,9 @@ class FlutterNativeStrings {
 
       final File arbFile = fileSystem.file(arbFilePath);
       final String arbFileContentAsString = arbFile.readAsStringSync();
-      final Map<String, dynamic> arbFileContentAsMap =
+      final Map<String, dynamic>? arbFileContentAsMap =
           json.jsonDecode(arbFileContentAsString);
-      final Map<String, dynamic> stringNameToContentMap = arbFileContentAsMap;
+      final Map<String, dynamic>? stringNameToContentMap = arbFileContentAsMap;
 
       androidStringResourceCreator.createStringResource(
           stringNameToContentMap: stringNameToContentMap,

--- a/lib/src/util/logger/logger.dart
+++ b/lib/src/util/logger/logger.dart
@@ -1,17 +1,16 @@
 import 'dart:io';
-import 'package:meta/meta.dart';
 
 class Logger implements LoggerI {
   final IOSink ioSink;
 
-  Logger({@required this.ioSink});
+  Logger({required this.ioSink});
 
   @override
-  void printMessage({@required String message}) {
+  void printMessage({required String message}) {
     ioSink.writeln(message);
   }
 }
 
 abstract class LoggerI {
-  void printMessage({@required String message});
+  void printMessage({required String message});
 }

--- a/lib/src/util/string_resource_creator/android_string_resource_creator.dart
+++ b/lib/src/util/string_resource_creator/android_string_resource_creator.dart
@@ -1,15 +1,14 @@
 import 'package:file/file.dart';
 import 'package:flutter_native_strings/src/util/logger/logger.dart';
 import 'package:flutter_native_strings/src/util/string_resource_creator/string_resource_creator_i.dart';
-import 'package:meta/meta.dart';
 import 'package:xml/xml.dart';
 
 class AndroidStringResourceCreator implements StringResourceCreatorI {
   @override
   void createStringResource(
-      {@required Map<String, dynamic> stringNameToContentMap,
-      @required FileSystem fileSystem,
-      @required LoggerI logger}) {
+      {required Map<String, dynamic>? stringNameToContentMap,
+      required FileSystem fileSystem,
+      required LoggerI logger}) {
     try {
       logger.printMessage(message: 'Generating android string resource...\n');
 
@@ -26,7 +25,7 @@ class AndroidStringResourceCreator implements StringResourceCreatorI {
       final XmlBuilder xmlBuilder = XmlBuilder();
       xmlBuilder.processing('xml', 'version="1.0" encoding="utf-8"');
 
-      final int numberOfStringsToGenerate = stringNameToContentMap.length;
+      final int numberOfStringsToGenerate = stringNameToContentMap!.length;
 
       xmlBuilder.element('resources', nest: () {
         for (var i = 0; i < numberOfStringsToGenerate; i++) {

--- a/lib/src/util/string_resource_creator/string_resource_creator_i.dart
+++ b/lib/src/util/string_resource_creator/string_resource_creator_i.dart
@@ -1,10 +1,9 @@
 import 'package:file/file.dart';
 import 'package:flutter_native_strings/src/util/logger/logger.dart';
-import 'package:meta/meta.dart';
 
 abstract class StringResourceCreatorI {
   void createStringResource(
-      {@required Map<String, dynamic> stringNameToContentMap,
-      @required FileSystem fileSystem,
-      @required LoggerI logger});
+      {required Map<String, dynamic>? stringNameToContentMap,
+      required FileSystem fileSystem,
+      required LoggerI logger});
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,426 +7,391 @@ packages:
       name: _fe_analyzer_shared
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "12.0.0"
+    version: "38.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.40.6"
+    version: "3.4.1"
   args:
     dependency: transitive
     description:
       name: args
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.6.0"
+    version: "2.3.0"
   async:
     dependency: transitive
     description:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0-nullsafety.2"
+    version: "2.9.0"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety.2"
+    version: "2.1.0"
   build:
     dependency: transitive
     description:
       name: build
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.6.2"
+    version: "2.2.1"
   built_collection:
     dependency: transitive
     description:
       name: built_collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.3.2"
+    version: "5.1.1"
   built_value:
     dependency: transitive
     description:
       name: built_value
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "7.1.0"
+    version: "8.1.4"
   charcode:
     dependency: transitive
     description:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0-nullsafety.2"
-  cli_util:
-    dependency: transitive
-    description:
-      name: cli_util
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.2.0"
+    version: "1.3.1"
   code_builder:
     dependency: transitive
     description:
       name: code_builder
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.7.0"
+    version: "4.1.0"
   collection:
     dependency: transitive
     description:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0-nullsafety.4"
+    version: "1.16.0"
   convert:
     dependency: transitive
     description:
       name: convert
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.1"
+    version: "3.0.1"
   coverage:
     dependency: transitive
     description:
       name: coverage
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.14.2"
+    version: "1.2.0"
   crypto:
     dependency: transitive
     description:
       name: crypto
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.5"
+    version: "3.0.1"
   dart_style:
     dependency: transitive
     description:
       name: dart_style
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.10"
+    version: "2.2.2"
   file:
     dependency: "direct main"
     description:
       name: file
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.2.1"
+    version: "6.1.2"
   fixnum:
     dependency: transitive
     description:
       name: fixnum
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.10.11"
+    version: "1.0.0"
+  frontend_server_client:
+    dependency: transitive
+    description:
+      name: frontend_server_client
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.1.2"
   glob:
     dependency: transitive
     description:
       name: glob
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "2.0.2"
   http_multi_server:
     dependency: transitive
     description:
       name: http_multi_server
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.2.0"
+    version: "3.2.0"
   http_parser:
     dependency: transitive
     description:
       name: http_parser
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.1.4"
-  intl:
-    dependency: transitive
-    description:
-      name: intl
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.16.1"
+    version: "4.0.0"
   io:
     dependency: transitive
     description:
       name: io
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.5"
+    version: "1.0.3"
   js:
     dependency: transitive
     description:
       name: js
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.6.3-nullsafety.2"
+    version: "0.6.4"
   logging:
     dependency: transitive
     description:
       name: logging
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.11.4"
+    version: "1.0.2"
   matcher:
     dependency: transitive
     description:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.10-nullsafety.2"
+    version: "0.12.11"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0-nullsafety.5"
+    version: "1.7.0"
   mime:
     dependency: transitive
     description:
       name: mime
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.9.7"
+    version: "1.0.1"
   mockito:
     dependency: "direct dev"
     description:
       name: mockito
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.1.4"
-  node_interop:
-    dependency: transitive
-    description:
-      name: node_interop
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.2.1"
-  node_io:
-    dependency: transitive
-    description:
-      name: node_io
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.2.0"
+    version: "5.1.0"
   node_preamble:
     dependency: transitive
     description:
       name: node_preamble
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.4.13"
+    version: "2.0.1"
   package_config:
     dependency: transitive
     description:
       name: package_config
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.9.3"
+    version: "2.0.2"
   path:
     dependency: transitive
     description:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0-nullsafety.2"
-  pedantic:
-    dependency: transitive
-    description:
-      name: pedantic
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.10.0-nullsafety.2"
+    version: "1.8.1"
   petitparser:
     dependency: transitive
     description:
       name: petitparser
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.1.0"
+    version: "5.0.0"
   pool:
     dependency: transitive
     description:
       name: pool
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.5.0-nullsafety.2"
+    version: "1.5.0"
   pub_semver:
     dependency: transitive
     description:
       name: pub_semver
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.4.4"
-  quiver:
-    dependency: transitive
-    description:
-      name: quiver
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.1.5"
+    version: "2.1.1"
   shelf:
     dependency: transitive
     description:
       name: shelf
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.7.9"
+    version: "1.3.0"
   shelf_packages_handler:
     dependency: transitive
     description:
       name: shelf_packages_handler
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.1"
+    version: "3.0.0"
   shelf_static:
     dependency: transitive
     description:
       name: shelf_static
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.9+2"
+    version: "1.1.0"
   shelf_web_socket:
     dependency: transitive
     description:
       name: shelf_web_socket
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.4+1"
+    version: "1.0.1"
   source_gen:
     dependency: transitive
     description:
       name: source_gen
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.9.10+2"
+    version: "1.2.1"
   source_map_stack_trace:
     dependency: transitive
     description:
       name: source_map_stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety.3"
+    version: "2.1.0"
   source_maps:
     dependency: transitive
     description:
       name: source_maps
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.10.10-nullsafety.2"
+    version: "0.10.10"
   source_span:
     dependency: transitive
     description:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0-nullsafety.2"
+    version: "1.8.2"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.10.0-nullsafety.5"
+    version: "1.10.0"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety.2"
+    version: "2.1.0"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety.2"
+    version: "1.1.0"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0-nullsafety.2"
+    version: "1.2.0"
   test:
     dependency: "direct dev"
     description:
       name: test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.16.0-nullsafety.7"
+    version: "1.20.2"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19-nullsafety.4"
+    version: "0.4.9"
   test_core:
     dependency: transitive
     description:
       name: test_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.12-nullsafety.7"
+    version: "0.4.11"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0-nullsafety.4"
+    version: "1.3.0"
   vm_service:
     dependency: transitive
     description:
       name: vm_service
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.5.0"
+    version: "8.2.2"
   watcher:
     dependency: transitive
     description:
       name: watcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.9.7+15"
+    version: "1.0.1"
   web_socket_channel:
     dependency: transitive
     description:
       name: web_socket_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "2.1.0"
   webkit_inspection_protocol:
     dependency: transitive
     description:
       name: webkit_inspection_protocol
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.7.5"
+    version: "1.0.0"
   xml:
     dependency: "direct main"
     description:
       name: xml
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.5.1"
+    version: "6.0.1"
   yaml:
     dependency: transitive
     description:
       name: yaml
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.2.1"
+    version: "3.1.0"
 sdks:
-  dart: ">=2.10.0 <2.11.0"
+  dart: ">=2.16.0 <3.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,12 +4,12 @@ version: 0.0.1
 repository: https://github.com/victoreronmosele/flutter-native-strings
 
 environment:
-  sdk: ">=2.7.0 <3.0.0"
+  sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
-  xml: ^4.5.1
-  file: ^5.2.1
+  xml: ^6.0.1
+  file: ^6.1.2
 
 dev_dependencies:
-  mockito: ^4.1.3
-  test: ^1.16.0-nullsafety.5
+  mockito: ^5.1.0
+  test: ^1.20.2

--- a/test/unit_tests/flutter_native_strings_test.dart
+++ b/test/unit_tests/flutter_native_strings_test.dart
@@ -1,5 +1,4 @@
 import 'dart:convert' as json;
-import 'dart:io';
 
 import 'package:file/file.dart';
 import 'package:file/memory.dart';
@@ -18,14 +17,16 @@ void main() {
   group(FlutterNativeStrings, () {
     final String arbFilePath = 'assets/en.arb';
 
-    FlutterNativeStrings flutterNativeStrings;
-    StringResourceCreatorI mockStringResourceCreator;
-    FileSystem memoryFileSystem;
+    late FlutterNativeStrings flutterNativeStrings;
+    late StringResourceCreatorI mockStringResourceCreator;
+    late FileSystem memoryFileSystem;
+    late MockLogger mockLogger;
 
     setUp(() {
       flutterNativeStrings = FlutterNativeStrings();
       mockStringResourceCreator = MockStringResourceCreator();
       memoryFileSystem = MemoryFileSystem();
+      mockLogger = MockLogger();
 
       final File arbFile = memoryFileSystem.file(arbFilePath);
       arbFile.createSync(recursive: true);
@@ -36,14 +37,14 @@ void main() {
         'calls androidStringResourceCreator\'s createStringResource() method when run',
         () {
       flutterNativeStrings.generateNativeStrings(
-          logger: MockLogger(),
+          logger: mockLogger,
           fileSystem: memoryFileSystem,
           arbFilePath: arbFilePath,
           androidStringResourceCreator: mockStringResourceCreator);
 
       verify(mockStringResourceCreator.createStringResource(
-          fileSystem: anyNamed('fileSystem'),
-          logger: anyNamed('logger'),
+          fileSystem: memoryFileSystem,
+          logger: mockLogger,
           stringNameToContentMap: anyNamed('stringNameToContentMap')));
     });
 
@@ -53,8 +54,8 @@ void main() {
         () {
       /// To simulate any exception being thrown
       when(mockStringResourceCreator.createStringResource(
-              fileSystem: anyNamed('fileSystem'),
-              logger: anyNamed('logger'),
+              fileSystem: memoryFileSystem,
+              logger: mockLogger,
               stringNameToContentMap: anyNamed('stringNameToContentMap')))
           .thenThrow(Exception(''));
 

--- a/test/unit_tests/util/android_string_resource_creator_test.dart
+++ b/test/unit_tests/util/android_string_resource_creator_test.dart
@@ -1,5 +1,3 @@
-import 'dart:io';
-
 import 'package:file/file.dart';
 import 'package:file/memory.dart';
 import 'package:flutter_native_strings/src/util/logger/logger.dart';
@@ -17,7 +15,7 @@ void main() {
       'hello': 'Hello',
     };
 
-    FileSystem memoryFileSystem;
+    late FileSystem memoryFileSystem;
 
     setUp(() async {
       memoryFileSystem = MemoryFileSystem();

--- a/test/unit_tests/util/logger_test.dart
+++ b/test/unit_tests/util/logger_test.dart
@@ -8,7 +8,7 @@ class MockIOSink extends Mock implements IOSink {}
 
 void main() {
   group(Logger, () {
-    MockIOSink mockIOSink;
+    late MockIOSink mockIOSink;
 
     setUp(() {
       mockIOSink = MockIOSink();
@@ -21,10 +21,6 @@ void main() {
       logger.printMessage(message: testMessage);
 
       verify(mockIOSink.writeln(testMessage));
-    });
-
-    tearDown(() {
-      mockIOSink.close();
     });
   });
 }


### PR DESCRIPTION
This PR migrates the project to null-safety following the guide written [here](https://dart.dev/null-safety#migrate). 